### PR TITLE
Fix redis connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ CACHE_DRIVER=file // defaults to FILE
 ## Usage
 
 ```ts
-import Cache from '@ioc:Kaperskyguru/Adonis-Cache'
+import Cache from '@ioc:Kaperskyguru/Adonis-cache'
 
 let posts = await Cache.remember('_posts_', 60, async function () {
 	return await Post.all()

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ CACHE_DRIVER=file // defaults to FILE
 ## Usage
 
 ```ts
-import Cache from '@ioc:Kaperskyguru/Adonis-cache'
+import Cache from '@ioc:Kaperskyguru/Adonis-Cache'
 
 let posts = await Cache.remember('_posts_', 60, async function () {
 	return await Post.all()

--- a/src/Engines/RedisCache.ts
+++ b/src/Engines/RedisCache.ts
@@ -46,7 +46,7 @@ class RedisCache implements EngineInterface {
 			)
 		}
 
-		return this.redis.connection(this.config.connections)
+		return this.redis.connection()
 	}
 
 	/**


### PR DESCRIPTION
When using the redis cache driver, I'm getting the error:
Define config for "[object Object]" connection inside "config/redis" file

It seems like adonis-cache sends the object of connections to Redis.connection(name).

This Pull Request removes the name/object from the connection function, which makes the RedisManager use the default connection:
https://github.com/adonisjs/redis/blob/develop/src/RedisManager/index.ts#L112

Not sure if there was an use case for the current solution?
But this update fixes the redis connection for me.